### PR TITLE
chore: replace `camerdevs` by `jobsika`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 # vendor/
 
 #application
-camerdevs
+jobsika
 postgres-data
 .env
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then run the api:
 `make run`
 
 ##### Build and run
-`make run && ./camerdevs`
+`make run && ./jobsika`
 
 #### Build and run with docker
 `make docker-build && make docker-run`

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-APPNAME=camerdevs
+APPNAME=jobsika
 E2ETEST_DEPS=./e2etests/node_modules
 
 .DEFAULT_GOAL := help
@@ -58,12 +58,12 @@ docker-e2etest: $(E2ETEST_DEPS)
 ## docker-build: build the api docker image
 .PHONY: docker-build
 docker-build:
-	docker build -t camerdevs .
+	docker build -t jobsika .
 
 ## docker-run: run the api docker container
 .PHONY: docker-run
 docker-run:
-	docker run -p 7000:7000 --env-file .docker-env camerdevs
+	docker run -p 7000:7000 --env-file .docker-env jobsika
 
 .PHONY: install_goose
 install_goose:

--- a/backend/docs/companies.go
+++ b/backend/docs/companies.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 // swagger:route GET /companies companies idOfCompanyWithoutID

--- a/backend/docs/company_ratings.go
+++ b/backend/docs/company_ratings.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 // swagger:route GET /company-ratings company-ratings idOfCompanyRatingsWithoutID

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1,6 +1,6 @@
 // Package classification Camerdevs API.
 //
-// Documentation of our camerdevs API.
+// Documentation of our jobsika API.
 //
 //     Schemes: http, https
 //     BasePath: /

--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 // swagger:route GET /ratings ratings idOfRatingWithoutID

--- a/backend/docs/salaries.go
+++ b/backend/docs/salaries.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 // swagger:route GET /salaries salaries idOfSalaryWithoutID

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module github.com/elhmn/camerdevs
+module github.com/elhmn/jobsika
 
 go 1.16
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"os"
 
-	"github.com/elhmn/camerdevs/internal/storage"
+	"github.com/elhmn/jobsika/internal/storage"
 	"github.com/joho/godotenv"
 )
 

--- a/backend/internal/handlers/cities_handler.go
+++ b/backend/internal/handlers/cities_handler.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"github.com/elhmn/camerdevs/internal/server"
+	"github.com/elhmn/jobsika/internal/server"
 	log "github.com/sirupsen/logrus"
 	"net/http"
 

--- a/backend/internal/handlers/companies_handler.go
+++ b/backend/internal/handlers/companies_handler.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/elhmn/camerdevs/internal/server"
+	"github.com/elhmn/jobsika/internal/server"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )

--- a/backend/internal/handlers/company_ratings_handler.go
+++ b/backend/internal/handlers/company_ratings_handler.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/elhmn/camerdevs/internal/server"
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/internal/server"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	log "github.com/sirupsen/logrus"

--- a/backend/internal/handlers/jobtitles_handler.go
+++ b/backend/internal/handlers/jobtitles_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/elhmn/camerdevs/internal/server"
+	"github.com/elhmn/jobsika/internal/server"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elhmn/camerdevs/internal/server"
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/internal/server"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )

--- a/backend/internal/handlers/salaries_handler.go
+++ b/backend/internal/handlers/salaries_handler.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/elhmn/camerdevs/internal/server"
+	"github.com/elhmn/jobsika/internal/server"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )

--- a/backend/internal/handlers/seniority_handler.go
+++ b/backend/internal/handlers/seniority_handler.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 	"github.com/gin-gonic/gin"
 )
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -1,8 +1,8 @@
 package server
 
 import (
-	"github.com/elhmn/camerdevs/internal/config"
-	"github.com/elhmn/camerdevs/internal/storage"
+	"github.com/elhmn/jobsika/internal/config"
+	"github.com/elhmn/jobsika/internal/storage"
 )
 
 //Server defines the api server struct

--- a/backend/internal/storage/cities.go
+++ b/backend/internal/storage/cities.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 	"os"
 )
 

--- a/backend/internal/storage/companies.go
+++ b/backend/internal/storage/companies.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"os"
 
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 //GetCompanies get companies

--- a/backend/internal/storage/company_ratings.go
+++ b/backend/internal/storage/company_ratings.go
@@ -1,6 +1,6 @@
 package storage
 
-import "github.com/elhmn/camerdevs/pkg/models/v1beta"
+import "github.com/elhmn/jobsika/pkg/models/v1beta"
 
 //GetCompanyRatings get company ratings
 func (db DB) GetCompanyRatings(query v1beta.CompanyRatingQuery) ([]v1beta.CompanyRating, error) {

--- a/backend/internal/storage/jobtitles.go
+++ b/backend/internal/storage/jobtitles.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"os"
 
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 )
 
 //GetJobTitles get jobtitles

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/elhmn/jobsika/pkg/models/v1beta"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )

--- a/backend/internal/storage/salaries.go
+++ b/backend/internal/storage/salaries.go
@@ -1,6 +1,6 @@
 package storage
 
-import "github.com/elhmn/camerdevs/pkg/models/v1beta"
+import "github.com/elhmn/jobsika/pkg/models/v1beta"
 
 //GetSalaries get salaries
 func (db DB) GetSalaries() ([]v1beta.Salary, error) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	_ "github.com/elhmn/camerdevs/docs"
-	"github.com/elhmn/camerdevs/internal/handlers"
+	_ "github.com/elhmn/jobsika/docs"
+	"github.com/elhmn/jobsika/internal/handlers"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -14,7 +14,7 @@ definitions:
         type: integer
         x-go-name: Salary
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
   Company:
     description: Company defines the company structure
     properties:
@@ -38,7 +38,7 @@ definitions:
         type: string
         x-go-name: UpdatedAt
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
   Rating:
     description: |-
       Rating defines the rating structure
@@ -87,7 +87,7 @@ definitions:
         type: string
         x-go-name: Seniority
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
   RatingPostQuery:
     description: |-
       RatingPostQuery defines the body object used to
@@ -117,7 +117,7 @@ definitions:
         type: string
         x-go-name: Seniority
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
   RatingResponse:
     properties:
       hits:
@@ -138,7 +138,7 @@ definitions:
         type: integer
         x-go-name: Offset
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
   Salary:
     description: Salary defines the salary structure
     properties:
@@ -183,10 +183,10 @@ definitions:
         type: string
         x-go-name: UpdatedAt
     type: object
-    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+    x-go-package: github.com/elhmn/jobsika/pkg/models/v1beta
 host: localhost:7000
 info:
-  description: Documentation of our camerdevs API.
+  description: Documentation of our jobsika API.
   title: Camerdevs API.
   version: 1.0.0
 paths:

--- a/docs/how-to-add-a-new-table.md
+++ b/docs/how-to-add-a-new-table.md
@@ -1,4 +1,4 @@
-1. Open [`migrations/20211019221200_init_db.sql`](https://github.com/osscameroon/camerdevs/blob/main/backend/migrations/20211019221200_init_db.sql)
+1. Open [`migrations/20211019221200_init_db.sql`](https://github.com/osscameroon/jobsika/blob/main/backend/migrations/20211019221200_init_db.sql)
 2. Add your new table schema in the file, between the `-- +goose Up \n -- +goose StatementBegin` and `-- +goose StatementEnd` lines
 Example:
 ```sql
@@ -18,7 +18,7 @@ Example:
 DROP TABLE IF EXISTS <your_new_table>;
 ```
 
-4. Create a fixture file `<your_new_table>.sql` for that will be used to populate your table in this [location](https://github.com/osscameroon/camerdevs/tree/main/backend/fixtures/postgres/sql).
+4. Create a fixture file `<your_new_table>.sql` for that will be used to populate your table in this [location](https://github.com/osscameroon/jobsika/tree/main/backend/fixtures/postgres/sql).
  Note: You can use [mockaroo](https://www.mockaroo.com/) to generate the fixture data.
 
-5. Add the `../../fixtures/postgres/sql/<your_new_table>.sql` in the appropriate position on that [`sql_file_ordered.txt`](https://github.com/osscameroon/camerdevs/blob/main/backend/scripts/setup-postgres/sql_file_ordered.txt) file. This  is used to specify the order in which your sql fixtures files will be applied to the Database.
+5. Add the `../../fixtures/postgres/sql/<your_new_table>.sql` in the appropriate position on that [`sql_file_ordered.txt`](https://github.com/osscameroon/jobsika/blob/main/backend/scripts/setup-postgres/sql_file_ordered.txt) file. This  is used to specify the order in which your sql fixtures files will be applied to the Database.

--- a/frontend/components/Footer.vue
+++ b/frontend/components/Footer.vue
@@ -2,7 +2,7 @@
   <footer
     class="site__footer mt-10 md:mt-28 flex flex-col md:flex-row items-center justify-center"
   >
-    <a href="https://github.com/osscameroon/camerdevs">
+    <a href="https://github.com/osscameroon/jobsika">
       <img :src="github" alt="logo" class="site__footer-img w-8 h-8" />
     </a>
     <p class="site__footer-copyrigth text-xs md:text-sm md:ml-7 mt-3 md:mt-0">


### PR DESCRIPTION
Replaces all occurrences of `camerdevs` by `jobsika`.

The `./.github/workflows/backend-build-api-image.yaml` was excluded in purpose as editing this file would have broken the deployment.