### PR TITLE
Align table titles with corresponding items

### DIFF
--- a/frontend/components/Company.vue
+++ b/frontend/components/Company.vue
@@ -16,42 +16,42 @@
               <tr>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   Company
                 </th>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   Jobs title
                 </th>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   Seniority
                 </th>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   City
                 </th>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   Salary
                 </th>
                 <th
                   scope="col"
-                  class="px-6 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
+                  class="px-4 py-3 text-left text-xs md:text-sm font-bold tracking-wider"
                   style="color: #b1b1b1; font-family: 'Inter', sans-serif"
                 >
                   Rating


### PR DESCRIPTION
Align table titles with corresponding items

Why ?
To give a better visual.

How ?
Changed the horizontal padding of `th` from `px-6` to `px-4`

Steps to verify:
Display the home page.

** Screenshots (optional)
![image](https://user-images.githubusercontent.com/9080102/166136432-bbd5ae35-1100-4582-a458-5de34e83afe0.png)

Should close #302 