### PR TITLE
Update tooltip color from gray c to dark gray

### DIFF
--- a/frontend/components/Title.vue
+++ b/frontend/components/Title.vue
@@ -33,7 +33,7 @@
           </h2>
           <div class="flex items-center -mb-1">
             <span
-              class="cursor-pointer h-5 text-center w-5 ml-2 text-grayC rounded-full border border-grayC text-xs"
+              class="cursor-pointer h-5 text-center w-5 ml-2 text-grayDark rounded-full border border-grayDark text-xs"
               :class="{ opened: opened.includes(tooltips[0].id) }"
               @click="toggle(tooltips[0].id)"
             >

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,8 @@ module.exports = {
       'white': '#ffffff',
       'blue': '#7994A0',
       'blueDark': '#235365',
-      'grayC': '#b1b1b1'
+      'grayC': '#b1b1b1',
+      'grayDark': '#504E57'
     }
   },
   variants: {


### PR DESCRIPTION
Issue : https://github.com/osscameroon/jobsika/issues/326

This pull request updates tooltip's color from grayC to grayDark

Why ?
It's not very visible. The first time I used the site, I didn't see it then I decided to do a PR in order to add a dark gray color more visible. Then, the user will easily click on this tooltip to get the extra information.

How ?
I added grayDark color in tailwind.config.js then I used that in Title.vue

Steps to verify:
Just compare the visibility before and after this change. This color is a dark one so it is easy for the user to pay attention on this detail.

Screenshots:

Before
![jobsika_tooltip_before](https://user-images.githubusercontent.com/25267726/166228363-31e60343-29c7-4f6d-b0a5-e01aaf8fb522.PNG)

After
![jobsika_tooltip_after](https://user-images.githubusercontent.com/25267726/166228405-06b7d2d6-ac4d-4b97-bb3f-cf62f965592c.PNG)

