### PR TITLE
Don't calculate average ratings for hidden companys data

### DIFF
--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -151,15 +151,15 @@ describe(`${endpoint2}`, function () {
         });
     });
 
-    it("return the average of ratings with company=Jaxbean", async function () {
+    it("return the average of ratings with company=Fliptune", async function () {
       return request(apiHost)
-        .get(`${endpoint2}?company=Jaxbean`)
+        .get(`${endpoint2}?company=Fliptune`)
         .send()
         .expect(200)
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
           expect(JSON.stringify(res.body)).equal(
-            '{"rating":0,"salary":1624669}'
+            '{"rating":0,"salary":841396}'
           );
         });
     });
@@ -190,7 +190,7 @@ describe(`${endpoint2}`, function () {
         });
     });
 
-      it("add 2 rating entry for one company, one with rating set to 0 and another set to 5, the result should be 5 instead of 2", async function() {
+      it("add 3 rating entry for one company, one with rating set to 0 and another set to 5, the result should be 5 instead of 2", async function() {
           const sendRequest = (rating) =>
               request(apiHost)
                   .post(`${endpoint}`)
@@ -213,6 +213,7 @@ describe(`${endpoint2}`, function () {
                   .expect("Content-Type", "application/json; charset=utf-8");
 
           await sendRequest(0)
+          await sendRequest(0)
           await sendRequest(5)
 
           return request(apiHost)
@@ -224,6 +225,43 @@ describe(`${endpoint2}`, function () {
               .then((res) => {
                   const averageRating = res.body.rating;
                   expect(averageRating).equal(5);
+              });
+      });
+
+      it("add 2 rating entry for one company with rating set to 5, the result should be 0 instead of 5 due to maxEntryBeforeDisplay rules", async function() {
+          const sendRequest = (rating) =>
+              request(apiHost)
+                  .post(`${endpoint}`)
+                  .set("Accept", "application/json")
+                  .send({
+                      company_name: "Ossrating0",
+                      job_title: "technicien de surface",
+                      //we set the salary to zero to avoid breaking the average-ratings tests
+                      //as the salary set -1 are not counted in the calculation of the average
+                      salary: 0,
+                      //we set the rating to zero to avoid breaking the average-ratings tests
+                      //as the rating set -1 are not counted in the calculation of the average
+                      rating: rating,
+                      comment: "my comment",
+                      seniority: "Seniority",
+                      city: "maroua",
+                      //the country field is omitted here as we always set it to Cameroon for now
+                  })
+                  .expect(201)
+                  .expect("Content-Type", "application/json; charset=utf-8");
+
+          await sendRequest(5)
+          await sendRequest(5)
+
+          return request(apiHost)
+              .get(`${endpoint2}?company=Ossrating0`)
+              .set("Accept", "application/json")
+              .send()
+              .expect(200)
+              .expect("Content-Type", "application/json; charset=utf-8")
+              .then((res) => {
+                  const averageRating = res.body.rating;
+                  expect(averageRating).equal(0);
               });
       });
   });

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -151,7 +151,12 @@ func (db DB) GetAverageRating(jobtitle, company, city, seniority string) (v1beta
 
 	query := db.queryRatings()
 	if company != "" {
-		query = query.Where("c.name = ?", company)
+		query = query.Where(`
+		c.name = ?
+  		and (Select count(ss.id)
+       		from salaries ss
+       		where ss.title_id = s.title_id and 
+			ss.company_id = s.company_id) >= ?`, company, maxEntryBeforeDisplay)
 	}
 	if jobtitle != "" {
 		query = query.Where("j.title = ?", jobtitle)


### PR DESCRIPTION
This pull request hide entry who do not satisfy the maxEntryBeforeDisplay rules when calculating average-rating for a given  company.

Steps to verify:

- move to the backend folder with cd ./backend
- run make start-postrges to run an initialized database
- run make run to launch the api
- then run the command

1️⃣Add a rating for Ossco company

```shell
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "Douala","comment": "my comment","company_name": "Ossco","job_title": "Dev","rating": 5,"salary": 1200,"seniority": "CV"}'
```

you should see something like this 👇
```json
{"message":"created"}
```

2️⃣Get average-rating of Ossco
```shell
curl -s -X GET "http://localhost:7000/average-rating?company=Ossco"
```

you should see  👇
```json
{
    "rating": 0,
    "salary": 0
}
```

3️⃣Re-Execute the request on step one 2 times

2️⃣Get average-rating of Ossco
```shell
curl -s -X GET "http://localhost:7000/average-rating?company=Ossco"
```

you should see  👇
```json
{
    "rating": 5,
    "salary": 1200
}
```