### PR TITLE
backend: remove email subscriptions from a transaction

### DIFF
--- a/backend/internal/storage/subscribers.go
+++ b/backend/internal/storage/subscribers.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"github.com/osscameroon/jobsika/pkg/models/v1beta"
-	"gorm.io/gorm"
 )
 
 const JobSubscribersTableName = "job_subscribers"
@@ -10,22 +9,19 @@ const JobSubscribersTableName = "job_subscribers"
 func (db DB) PostSubscribers(query v1beta.SubscribersPostQuery) (*v1beta.Subscribers, error) {
 	subscriber := new(v1beta.Subscribers)
 
-	err := db.c.Transaction(func(tx *gorm.DB) error {
-		//Check if the subscriber email already exist
-		err := tx.Table(JobSubscribersTableName).Where("email = ?", query.Email).First(subscriber).Error
-		if err == nil {
-			return nil
-		}
+	//Check if the subscriber email already exist
+	err := db.c.Table(JobSubscribersTableName).Where("email = ?", query.Email).First(subscriber).Error
+	if err == nil {
+		return nil, err
+	}
 
-		subscriber.Email = query.Email
+	subscriber.Email = query.Email
 
-		err = tx.Table(JobSubscribersTableName).Create(subscriber).Error
-		if err != nil {
-			return err
-		}
+	err = db.c.Table(JobSubscribersTableName).Create(subscriber).Error
+	if err != nil {
+		return nil, err
+	}
 
-		return nil
-	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We should not use a transation here as when we first check the email, the transation will inevitably error if the email is not yet in the db.

