### PR TITLE
backend: update the ca-certificates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,13 @@
 FROM golang:alpine AS base
 
+# update the ca-certificates
+# more on https://github.com/google/go-github/issues/1049
+RUN apk update \
+        && apk upgrade \
+        && apk add --no-cache \
+        ca-certificates \
+        && update-ca-certificates 2>/dev/null || true
+
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
     GOOS=linux \
@@ -21,6 +29,10 @@ RUN cp /build/api .
 
 # build image with the binary
 FROM scratch
+
+# copy the ca-certificate.crt from the build stage
+# more on https://github.com/google/go-github/issues/1049#issuecomment-1023836581
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY --from=base /dist/api /
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file:
       - ./.docker-env
       - ./.api-env
+      - ./.opencollective-env
     volumes:
       - .:/api
     ports:


### PR DESCRIPTION
When running api, using docker swarm on linux the graphql calls failed with the following error:
```
time="2023-05-29T08:33:45Z" level=error msg="Post \"https://opencollective.com/api/graphql/v2\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
```

I suspect that it has something to with the ca-certificates on linux. I then followed the instructions from
https://github.com/google/go-github/issues/1049#issuecomment-454446363 and hope it will solve our issue