### PR TITLE
[#Readme] update readme ( add step to create opencollective-env base on opencollective-env-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To run the application locally, you should:
 
 #### Here is the detail steps you can take to install the required dependencies:
 - Jump to the ./backend folder: `cd ./backend`
+- Create opencollective env file: `cp .opencollective-env-example .opencollective-env`
 - Run the database: `make start-postgres`
 - Run the api: `make run`
 - Build and run: `make run && ./jobsika`


### PR DESCRIPTION
This pull request update the readme to add another primordial step to install projects dependancies

Why ?
when wanting to install the dependencies necessary for the projects, I realized that there was a missing step in the documentation without which I would get this error: Failed to load PROJECT_PATH/jobsika/backend/.opencollective-env: open PROJECT_PATH/jobsika/backend/.opencollective-env: no such file or directory

How ?
just add one line in readme

Steps to verify:
Write down few steps to help us test or verify what the pull request does

** Screenshots (optional)
![image](https://github.com/osscameroon/jobsika/assets/93648451/607c169f-90c6-40e8-9be4-f1ccf5bc727d)
