### PR TITLE
build: #459 Running Jobsika again after being updated for the last time 3 years ago

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,10 +1,11 @@
 APPNAME=jobsika
 E2ETEST_DEPS=./e2etests/node_modules
+DOCKER_COMPOSE=$(shell if command -v docker-compose >/dev/null 2>&1; then echo docker-compose; else echo docker compose; fi)
 
 .DEFAULT_GOAL := help
 
 define install_goose
-	go install github.com/pressly/goose/v3/cmd/goose@latest
+	go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
 endef
 
 
@@ -54,7 +55,7 @@ $(E2ETEST_DEPS):
 ## docker-e2etest: run e2etests in a docker compose
 docker-e2etest: $(E2ETEST_DEPS)
 	-rm -rf postgres-data
-	docker-compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from e2etests
+	$(DOCKER_COMPOSE) -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from e2etests
 
 ## docker-build: build the api docker image
 .PHONY: docker-build
@@ -96,17 +97,17 @@ endif
 
 ## start-api: starts the api and its dependencies in a docker container
 start-api:
-	docker-compose up
+	$(DOCKER_COMPOSE) up
 
 ## stop-api: stops the api and its dependencies in a docker container
 stop-api:
-	docker-compose down && \
+	$(DOCKER_COMPOSE) down && \
 	rm -rf postgres-data
 
 ## start-postgres: starts postgres sql, setup and populate yotas database
 start-postgres:
-	docker-compose up start-postgres
-	docker-compose logs -f
+	$(DOCKER_COMPOSE) up start-postgres
+	$(DOCKER_COMPOSE) logs -f
 
 ## connect-postgres: connect to postgres sql
 connect-postgres:
@@ -132,7 +133,7 @@ reset-postgres:
 
 ## stop-postgres: remove local postgres-data and teardown postgres
 stop-postgres:
-	docker-compose down && \
+	$(DOCKER_COMPOSE) down && \
 	rm -rf postgres-data
 
 .PHONY:check-swagger
@@ -156,7 +157,7 @@ install-deps:
 	go install github.com/kisielk/errcheck@latest
 	@echo "errcheck installed!"
 	@echo "installing goose..."
-	go install github.com/pressly/goose/v3/cmd/goose@latest
+	go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
 	@echo "goose installed!"
 	@echo "installing swagger..."
 	go install github.com/go-swagger/go-swagger/cmd/swagger@latest

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,7 @@
 APPNAME=jobsika
 E2ETEST_DEPS=./e2etests/node_modules
 DOCKER_COMPOSE=$(shell if command -v docker-compose >/dev/null 2>&1; then echo docker-compose; else echo docker compose; fi)
+ERRCHECK_VERSION=v1.6.3
 
 .DEFAULT_GOAL := help
 
@@ -154,7 +155,7 @@ install-deps:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.23.8
 	@echo "golangci installed!"
 	@echo "installing errcheck..."
-	go install github.com/kisielk/errcheck@latest
+	go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
 	@echo "errcheck installed!"
 	@echo "installing goose..."
 	go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
@@ -169,7 +170,7 @@ ifeq (, $(shell which golangci-lint))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.23.8
 endif
 ifeq (, $(shell which errcheck))
-	go install github.com/kisielk/errcheck@latest
+	go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
 endif
 
 ## lint: run linters over the entire code base

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - postgres
     restart: always
-    image: golang:buster
+    image: golang:1.23-bookworm
     command: /api/scripts/wait-for-it/wait-for-it.sh postgres:5432 -t 120 -- /api/scripts/setup-postgres/setup-postgres-and-run-api.sh
     env_file:
       - ./.docker-env

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - postgres
     #replace this with an image that contains dependencies required by setup-postgres.sh
-    image: golang:buster
+    image: golang:1.23-bookworm
     command: /api/scripts/wait-for-it/wait-for-it.sh postgres:5432 -t 120 -- /api/scripts/setup-postgres/setup-postgres.sh
     env_file:
       - ./.docker-env

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   api:
     depends_on:
       - start-postgres
-    image: golang:buster
+    image: golang:1.23-bookworm
     command: ["/bin/bash", "-c", "cd /api/ && make run"]
     env_file:
       - ./.docker-env

--- a/backend/scripts/populate_db.sh
+++ b/backend/scripts/populate_db.sh
@@ -7,15 +7,13 @@ fi
 
 #install goose
 if [[ -z "$(which goose)" ]]; then
-	go install github.com/pressly/goose/v3/cmd/goose@latest
+	go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
 fi
 
 #install psql
 if [[ -z "$(which psql)" ]]; then
-	sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 	apt-get update
-	apt-get -y install postgresql
+	apt-get -y install postgresql-client
 fi
 
 ./goose-up.sh $ENV_FILE

--- a/backend/scripts/setup-postgres/setup-postgres.sh
+++ b/backend/scripts/setup-postgres/setup-postgres.sh
@@ -8,15 +8,13 @@ ENV_FILE=/api/.docker-env
 
 #install goose
 if [[ -z "$(which goose)" ]]; then
-	go install github.com/pressly/goose/v3/cmd/goose@latest
+	go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
 fi
 
 #install psql
 if [[ -z "$(which psql)" ]]; then
-	sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 	apt-get update
-	apt-get -y install postgresql
+	apt-get -y install postgresql-client
 fi
 
 cd /api/scripts

--- a/frontend/run-dev.cmd
+++ b/frontend/run-dev.cmd
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+set BASE_URL=http://localhost:7000
+node node_modules\nuxt\bin\nuxt.js --hostname 127.0.0.1 --port 3000

--- a/frontend/run-dev.ps1
+++ b/frontend/run-dev.ps1
@@ -1,0 +1,2 @@
+Set-Location -LiteralPath $PSScriptRoot
+& "C:\Program Files\nodejs\npx.cmd" nuxt --hostname 127.0.0.1 --port 3000 *>&1 | Tee-Object -FilePath (Join-Path $PSScriptRoot "nuxt-live.log")


### PR DESCRIPTION
Fix #459 

Here’s what changed, grouped by type.

Real Content Changes

[backend/docker-compose.yml](C:/GitHub/jobsika/backend/docker-compose.yml)
Changed the start-postgres helper image from:
image: golang:buster
to:
image: golang:1.23-bookworm
Reason: golang:buster is old. Its Debian Buster package repositories failed with 404, so the setup container could not install psql.
[backend/scripts/setup-postgres/setup-postgres.sh](C:/GitHub/jobsika/backend/scripts/setup-postgres/setup-postgres.sh)
Pinned Goose from latest to v3.15.1:
go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
Reason: latest required a newer Go version than the old container supported.
  Also replaced full PostgreSQL install with client-only install:
apt-get -y install postgresql-client
Reason: the setup script only needs psql, not a full PostgreSQL server.
  Removed the custom PostgreSQL apt repo setup because Bookworm already provides postgresql-client.
Line Ending Fixes
These files were converted from Windows CRLF to Unix LF so they can run inside Linux Docker containers:
[backend/scripts/connect_to_postgres.sh](C:/GitHub/jobsika/backend/scripts/connect_to_postgres.sh)
[backend/scripts/goose-down.sh](C:/GitHub/jobsika/backend/scripts/goose-down.sh)
[backend/scripts/goose-reset.sh](C:/GitHub/jobsika/backend/scripts/goose-reset.sh)
[backend/scripts/goose-up.sh](C:/GitHub/jobsika/backend/scripts/goose-up.sh)
[backend/scripts/populate_db.sh](C:/GitHub/jobsika/backend/scripts/populate_db.sh)
[backend/scripts/setup-postgres/setup-postgres-and-run-api.sh](C:/GitHub/jobsika/backend/scripts/setup-postgres/setup-postgres-and-run-api.sh)
[backend/scripts/setup-postgres/setup-postgres-and-test.sh](C:/GitHub/jobsika/backend/scripts/setup-postgres/setup-postgres-and-test.sh)
[backend/scripts/setup-postgres/setup-postgres.sh](C:/GitHub/jobsika/backend/scripts/setup-postgres/setup-postgres.sh)
[backend/scripts/setup-postgres/test.sh](C:/GitHub/jobsika/backend/scripts/setup-postgres/test.sh)
[backend/scripts/wait-for-it/wait-for-it.sh](C:/GitHub/jobsika/backend/scripts/wait-for-it/wait-for-it.sh)
Reason: Docker was failing with errors like bash\r: No such file or directory.
[backend/scripts/setup-postgres/sql_file_ordered.txt](C:/GitHub/jobsika/backend/scripts/setup-postgres/sql_file_ordered.txt)
Also converted from CRLF to LF.
Reason: psql was trying to load fixture paths with a hidden \r at the end, causing “No such file or directory”.

Added Helper Files

[frontend/run-dev.cmd](C:/GitHub/jobsika/frontend/run-dev.cmd)
Added a Windows launcher:
@echo off
cd /d "%~dp0"
set BASE_URL=http://localhost:7000
node node_modules\nuxt\bin\nuxt.js --hostname 127.0.0.1 --port 3000
Purpose: start Nuxt on Windows using the local backend without editing .env.
[frontend/run-dev.ps1](C:/GitHub/jobsika/frontend/run-dev.ps1)
Added a PowerShell launcher that starts Nuxt and writes logs to nuxt-live.log.
Purpose: debugging/attempting stable frontend startup.
Ignored Local Env Files
I also created local ignored env files during setup:
backend/.opencollective-env
frontend/.env
frontend/.env is back to the staged API value. The correct local-backend run uses a temporary BASE_URL=http://localhost:7000 process env instead of changing .env.

-----------------------

Screenshots:

<img width="1901" height="942" alt="Screenshot 2026-07-19 202557" src="https://github.com/user-attachments/assets/ab8ecb80-a6a8-456f-9cba-bb5fc2f3d175" />
<img width="1917" height="965" alt="Screenshot 2026-07-19 202748" src="https://github.com/user-attachments/assets/d2099ebe-83bb-4898-84a0-4a3fc5add941" />

<img width="1895" height="956" alt="Screenshot 2026-07-19 202831" src="https://github.com/user-attachments/assets/02b680fb-614c-41b0-a3d0-9618f30e3dda" />

<img width="1915" height="965" alt="Screenshot 2026-07-19 202859" src="https://github.com/user-attachments/assets/3f83b146-d2af-4320-954d-3f4dd853f0c0" />

<img width="1912" height="905" alt="Screenshot 2026-07-19 204324" src="https://github.com/user-attachments/assets/4e9cfe6f-1f3b-4c9d-bd6d-76934dd29d7e" />

<img width="1910" height="933" alt="Screenshot 2026-07-19 204405" src="https://github.com/user-attachments/assets/a485cd23-f44c-4e8d-9fd5-b258c0787d73" />

<img width="1867" height="903" alt="Screenshot 2026-07-19 204459" src="https://github.com/user-attachments/assets/39ffd25e-5e68-4a66-8419-62a78131bd4e" />

<img width="1867" height="902" alt="image" src="https://github.com/user-attachments/assets/d41711db-2962-418b-986e-ef5d94b1f517" />


